### PR TITLE
Update .gitignore to skip .idea IDE settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 .metadata/
 .settings/
 .project


### PR DESCRIPTION
Update .gitignore to ignore IDE settings for jetBrains/IDEA products. (IntelliJ, wWebStorm, etc.)